### PR TITLE
Eliminate progress bar flickering

### DIFF
--- a/src/indicators.hpp
+++ b/src/indicators.hpp
@@ -2979,6 +2979,9 @@ private:
 public:
   void print_progress() {
     std::lock_guard<std::mutex> lock{mutex_};
+    // signal start of screen update
+    // per https://gitlab.com/gnachman/iterm2/-/wikis/synchronized-updates-spec
+    std::cout << "\033[?2026h";
     auto &hide_bar_when_complete = get_value<details::ProgressBarOption::hide_bar_when_complete>();
     if (hide_bar_when_complete) {
       // Hide completed bars
@@ -3012,6 +3015,8 @@ public:
     }
     total_count_ = bars_.size();
     std::cout << termcolor::reset;
+    // signal end of screen update
+    std::cout << "\033[?2026l";
   }
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -135,7 +135,7 @@ int main(int argc, const char *argv[]) {
     uint64_t slice_start = 0;
 
     // create threads
-    for (auto i = 1; i <= processor_count; ++i) {
+    for (size_t i = 1; i <= processor_count; ++i) {
         uint64_t slice_end = slice_start + slice_size;
 
         // last thread might get fewer sectors than a normal slice


### PR DESCRIPTION
In supported terminals by using [iTerm2's synchronized update control codes](https://gitlab.com/gnachman/iterm2/-/wikis/synchronized-updates-spec)